### PR TITLE
XEP-0198: Stream Management

### DIFF
--- a/RNXMPP/RNXMPP.m
+++ b/RNXMPP/RNXMPP.m
@@ -82,9 +82,9 @@ RCT_EXPORT_METHOD(trustHosts:(NSArray *)hosts){
     [[RNXMPPService sharedInstance] trustHosts:hosts];
 }
 
-RCT_EXPORT_METHOD(connect:(NSString *)jid password:(NSString *)password auth:(AuthMethod) auth hostname:(NSString *)hostname port:(int)port){
+RCT_EXPORT_METHOD(setup:(NSString *)jid password:(NSString *)password auth:(AuthMethod) auth hostname:(NSString *)hostname port:(int)port){
     [RNXMPPService sharedInstance].delegate = self;
-    [[RNXMPPService sharedInstance] connect:jid withPassword:password auth:auth hostname:hostname port:port];
+    [[RNXMPPService sharedInstance] setup:jid withPassword:password auth:auth hostname:hostname port:port];
 }
 
 RCT_EXPORT_METHOD(disconnect){

--- a/RNXMPP/RNXMPP.m
+++ b/RNXMPP/RNXMPP.m
@@ -87,6 +87,11 @@ RCT_EXPORT_METHOD(setup:(NSString *)jid password:(NSString *)password auth:(Auth
     [[RNXMPPService sharedInstance] setup:jid withPassword:password auth:auth hostname:hostname port:port];
 }
 
+RCT_EXPORT_METHOD(connect){
+    [RNXMPPService sharedInstance].delegate = self;
+    [[RNXMPPService sharedInstance] connect];
+}
+
 RCT_EXPORT_METHOD(disconnect){
     [RNXMPPService sharedInstance].delegate = self;
     [[RNXMPPService sharedInstance] disconnect];

--- a/RNXMPP/RNXMPPService.h
+++ b/RNXMPP/RNXMPPService.h
@@ -9,6 +9,7 @@
 #import <Foundation/Foundation.h>
 
 #import "XMPP.h"
+#import "XMPPStreamManagementMemoryStorage.h"
 #import "XMPPReconnect.h"
 #import "XMPPDateTimeProfiles.h"
 #import "NSDate+XMPPDateTimeProfiles.h"
@@ -48,6 +49,8 @@
 
 @property (nonatomic, strong, readonly) XMPPStream *xmppStream;
 @property (nonatomic, strong, readonly) XMPPReconnect *xmppReconnect;
+@property (nonatomic, strong, readonly) XMPPStreamManagementMemoryStorage *xmppStreamStorage;
+@property (nonatomic, strong, readonly) XMPPStreamManagement *xmppStreamMgt;
 @property (nonatomic, strong, readonly) XMPPAutoPing *xmppAutoPing;
 @property (nonatomic, weak) id<RNXMPPServiceDelegate> delegate;
 

--- a/RNXMPP/RNXMPPService.h
+++ b/RNXMPP/RNXMPPService.h
@@ -57,6 +57,7 @@
 +(RNXMPPService *) sharedInstance;
 - (void)trustHosts:(NSArray *)hosts;
 - (BOOL)setup:(NSString *)myJID withPassword:(NSString *)myPassword auth:(AuthMethod)auth hostname:(NSString *)hostname port:(int)port;
+- (BOOL)connect;
 - (void)disconnect;
 -(void)sendStanza:(NSString *)stanza;
 

--- a/RNXMPP/RNXMPPService.h
+++ b/RNXMPP/RNXMPPService.h
@@ -56,7 +56,7 @@
 
 +(RNXMPPService *) sharedInstance;
 - (void)trustHosts:(NSArray *)hosts;
-- (BOOL)connect:(NSString *)myJID withPassword:(NSString *)myPassword auth:(AuthMethod)auth hostname:(NSString *)hostname port:(int)port;
+- (BOOL)setup:(NSString *)myJID withPassword:(NSString *)myPassword auth:(AuthMethod)auth hostname:(NSString *)hostname port:(int)port;
 - (void)disconnect;
 -(void)sendStanza:(NSString *)stanza;
 

--- a/RNXMPP/RNXMPPService.m
+++ b/RNXMPP/RNXMPPService.m
@@ -241,8 +241,14 @@ static const int ddLogLevel = LOG_LEVEL_INFO;
     xmppStream.hostName = (hostname ? hostname : [username componentsSeparatedByString:@"@"][1]);
     if(port){
         xmppStream.hostPort = port;
+    } else {
+        xmppStream.hostPort = 5222;
     }
 
+    return YES;
+}
+
+- (BOOL)connect
     NSError *error = nil;
     if (![xmppStream connectWithTimeout:30 error:&error])
     {

--- a/RNXMPP/RNXMPPService.m
+++ b/RNXMPP/RNXMPPService.m
@@ -223,7 +223,7 @@ static const int ddLogLevel = LOG_LEVEL_INFO;
 #pragma mark Connect/disconnect
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-- (BOOL)connect:(NSString *)myJID withPassword:(NSString *)myPassword auth:(AuthMethod)auth hostname:(NSString *)hostname port:(int)port
+- (BOOL)setup:(NSString *)myJID withPassword:(NSString *)myPassword auth:(AuthMethod)auth hostname:(NSString *)hostname port:(int)port
 {
     if (![xmppStream isDisconnected]) {
         [self disconnect];

--- a/RNXMPP/RNXMPPService.m
+++ b/RNXMPP/RNXMPPService.m
@@ -36,6 +36,8 @@ static const int ddLogLevel = LOG_LEVEL_INFO;
 
 @synthesize xmppStream;
 @synthesize xmppReconnect;
+@synthesize xmppStreamStorage;
+@synthesize xmppStreamMgt;
 @synthesize xmppAutoPing;
 
 +(RNXMPPService *) sharedInstance {
@@ -87,6 +89,11 @@ static const int ddLogLevel = LOG_LEVEL_INFO;
         xmppStream.enableBackgroundingOnSocket = YES;
     }
 #endif
+
+    // Setup xep-0198
+    xmppStreamStorage = [[XMPPStreamManagementMemoryStorage alloc] init];
+    xmppStreamMgt = [[XMPPStreamManagement alloc] initWithStorage: xmppStreamStorage];
+    [xmppStreamMgt activate: xmppStream];
 
     // Setup reconnect
     //

--- a/RNXMPP/RNXMPPService.m
+++ b/RNXMPP/RNXMPPService.m
@@ -254,7 +254,7 @@ static const int ddLogLevel = LOG_LEVEL_INFO;
     {
         DDLogError(@"Error connecting: %@", error);
         if (self.delegate){
-            [self.delegate onLoginError:error];
+            [self.delegate onLoginError: error];
         }
 
         return NO;

--- a/RNXMPP/RNXMPPService.m
+++ b/RNXMPP/RNXMPPService.m
@@ -248,7 +248,7 @@ static const int ddLogLevel = LOG_LEVEL_INFO;
     return YES;
 }
 
-- (BOOL)connect
+- (BOOL)connect {
     NSError *error = nil;
     if (![xmppStream connectWithTimeout:30 error:&error])
     {

--- a/RNXMPP/XMPPFramework.h
+++ b/RNXMPP/XMPPFramework.h
@@ -42,3 +42,7 @@
 
 #import "XMPPMUC.h"
 #import "XMPPRoomCoreDataStorage.h"
+
+// xep-0198
+#import "XMPPStreamManagement.h"
+#import "XMPPStreamManagementMemoryStorage.h"

--- a/android/src/main/java/rnxmpp/RNXMPPModule.java
+++ b/android/src/main/java/rnxmpp/RNXMPPModule.java
@@ -39,8 +39,14 @@ public class RNXMPPModule extends ReactContextBaseJavaModule implements rnxmpp.s
 
     @Override
     @ReactMethod
-    public void connect(String jid, String password, String authMethod, String hostname, Integer port){
-        this.xmppService.connect(jid, password, authMethod, hostname, port);
+    public void setup(String jid, String password, String authMethod, String hostname, Integer port){
+        this.xmppService.setup(jid, password, authMethod, hostname, port);
+    }
+
+    @Override
+    @ReactMethod
+    public void connect(){
+        this.xmppService.connect();
     }
 
     @Override

--- a/android/src/main/java/rnxmpp/service/XmppService.java
+++ b/android/src/main/java/rnxmpp/service/XmppService.java
@@ -15,7 +15,10 @@ public interface XmppService {
     public void trustHosts(ReadableArray trustedHosts);
 
     @ReactMethod
-    void connect(String jid, String password, String authMethod, String hostname, Integer port);
+    void setup(String jid, String password, String authMethod, String hostname, Integer port);
+
+    @ReactMethod
+    void connect();
 
     @ReactMethod
     void disconnect();

--- a/android/src/main/java/rnxmpp/service/XmppServiceSmackImpl.java
+++ b/android/src/main/java/rnxmpp/service/XmppServiceSmackImpl.java
@@ -84,6 +84,8 @@ public class XmppServiceSmackImpl implements XmppService, StanzaListener, Connec
             confBuilder.setCustomSSLContext(UnsafeSSLContext.INSTANCE.getContext());
         }
         XMPPTCPConnectionConfiguration connectionConfiguration = confBuilder.build();
+        XMPPTCPConnection.setUseStreamManagementDefault(true);
+        XMPPTCPConnection.setUseStreamManagementResumptionDefault(true);
         connection = new XMPPTCPConnection(connectionConfiguration);
 
         // Disable automatic roster request

--- a/android/src/main/java/rnxmpp/service/XmppServiceSmackImpl.java
+++ b/android/src/main/java/rnxmpp/service/XmppServiceSmackImpl.java
@@ -57,7 +57,7 @@ public class XmppServiceSmackImpl implements XmppService, StanzaListener, Connec
     }
 
     @Override
-    public void connect(String jid, String password, String authMethod, String hostname, Integer port) {
+    public void setup(String jid, String password, String authMethod, String hostname, Integer port) {
         final String[] jidParts = jid.split("@");
         String[] serviceNameParts = jidParts[1].split("/");
         String serviceName = serviceNameParts[0];
@@ -94,6 +94,14 @@ public class XmppServiceSmackImpl implements XmppService, StanzaListener, Connec
         connection.addAsyncStanzaListener(this, null);
         connection.addConnectionListener(this);
 
+        connect();
+    }
+
+    public void connect() {
+        if (connection == null) {
+            throw new RuntimeException("Cannot connect no connection!");
+        }
+
         new AsyncTask<Void, Void, Void>() {
 
             @Override
@@ -101,7 +109,7 @@ public class XmppServiceSmackImpl implements XmppService, StanzaListener, Connec
                 try {
                     connection.connect().login();
                 } catch (XMPPException | SmackException | IOException e) {
-                    logger.log(Level.SEVERE, "Could not login for user " + jidParts[0], e);
+                    logger.log(Level.SEVERE, "Could not login user", e);
                     if (e instanceof SASLErrorException){
                         XmppServiceSmackImpl.this.xmppServiceListener.onLoginError(((SASLErrorException) e).getSASLFailure().toString());
                     }else{

--- a/index.js
+++ b/index.js
@@ -147,6 +147,7 @@ class XMPP extends EventEmitter {
             hostname = (username+'@/').split('@')[1].split('/')[0];
         }
         React.NativeModules.RNXMPP.setup(username, password, auth, hostname, port);
+        React.NativeModules.RNXMPP.connect();
     }
 
     reconnect() {

--- a/index.js
+++ b/index.js
@@ -146,7 +146,11 @@ class XMPP extends EventEmitter {
         if (!hostname) {
             hostname = (username+'@/').split('@')[1].split('/')[0];
         }
-        React.NativeModules.RNXMPP.connect(username, password, auth, hostname, port);
+        React.NativeModules.RNXMPP.setup(username, password, auth, hostname, port);
+    }
+
+    reconnect() {
+        React.NativeModules.RNXMPP.connect();
     }
 
     sendStanza(stanza){


### PR DESCRIPTION
@nicolai86 PTAL + test on iOS

I needed to split setup/connect to match up with the Android interface where Smack doesn't reconnect automatically.

For iOS I would like to know if the `CONNECT` and `END` events are passed to the JS side. Does **XMPPFramework** reconnect automatically?