### PR TITLE
Remove inline-logging in favor of client-level logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,9 @@ class XMPP extends EventEmitter {
 
     onDisconnected(error) {
         this.emit(EVENTS.END);
+        if (error) {
+            this.emit(EVENTS.ERROR, error);
+        }
 
         var iqCallbacks = this.iqCallbacks;
         this.iqCallbacks = {};
@@ -74,9 +77,7 @@ class XMPP extends EventEmitter {
                 cb(new Error(`Disconnected: ${error}`));
             } catch (e) {
                 this.emit(EVENTS.ERROR,
-                    `Could not execute iq callback ${i} after disconnect`)
-                this.emit(EVENTS.ERROR, error)
-                this.emit(EVENTS.ERROR, e)
+                    `Could not execute iq callback ${i} after disconnect: ${e}`);
             }
         }
 


### PR DESCRIPTION
This PR removes the logging mechanisms inside the JavaScript binding. All `log` and `warn` calls are pre- or succeeded by appropriate events that are emitted, so the caller (our app) has all information on hand to perform the necessary steps for logging the events.