### PR TITLE
bug(android): handle premature stanza sending

### DIFF
--- a/android/src/main/java/rnxmpp/service/XmppServiceSmackImpl.java
+++ b/android/src/main/java/rnxmpp/service/XmppServiceSmackImpl.java
@@ -150,6 +150,11 @@ public class XmppServiceSmackImpl implements XmppService, StanzaListener, Connec
 
     @Override
     public void sendStanza(String stanza) {
+        if (connection == null) {
+            logger.log(Level.WARNING, "Connection has not been initialized yet, cannot send stanza " + stanza);
+            return
+        }
+
         StanzaPacket packet = new StanzaPacket(stanza);
         try {
             connection.sendPacket(packet);


### PR DESCRIPTION
Without this, android apps crash sometimes with a stack trace similar to this:

```
java.lang.NullPointerException: 
  at rnxmpp.service.XmppServiceSmackImpl.sendStanza(XmppServiceSmackImpl.java:155)
  at rnxmpp.RNXMPPModule.sendStanza(RNXMPPModule.java:61)
  at java.lang.reflect.Method.invoke(Native Method:0)
  at com.facebook.react.bridge.BaseJavaModule$JavaMethod.invoke(BaseJavaModule.java:345)
  at com.facebook.react.cxxbridge.JavaModuleWrapper.invoke(JavaModuleWrapper.java:136)
  at com.facebook.react.bridge.queue.NativeRunnable.run(Native Method:0)
  at android.os.Handler.handleCallback(Handler.java:751)
  at android.os.Handler.dispatchMessage(Handler.java:95)
  at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage(MessageQueueThreadHandler.java:31)
  at android.os.Looper.loop(Looper.java:154)
  at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run(MessageQueueThreadImpl.java:196)
  at java.lang.Thread.run(Thread.java:762)
```