### PR TITLE
fix(connection): reconnect and login only if not already done

### DIFF
--- a/android/src/main/java/rnxmpp/service/XmppServiceSmackImpl.java
+++ b/android/src/main/java/rnxmpp/service/XmppServiceSmackImpl.java
@@ -107,7 +107,21 @@ public class XmppServiceSmackImpl implements XmppService, StanzaListener, Connec
             @Override
             protected Void doInBackground(Void... params) {
                 try {
-                    connection.connect().login();
+
+                    /*
+                     * Normally, the reconnection logic would be handled by
+                     * the ReconnectionManager, but it seems that this does
+                     * not work reasonably well on Android. Therefore, we
+                     * provide this naive implementation ourselves.
+                     *
+                     * See https://stackoverflow.com/a/38178025
+                     */
+                    if (!connection.isConnected()) {
+                        connection.connect();
+                    }
+                    if (!connection.isAuthenticated()) {
+                        connection.login();
+                    }
                 } catch (XMPPException | SmackException | IOException e) {
                     logger.log(Level.SEVERE, "Could not login user", e);
                     if (e instanceof SASLErrorException){


### PR DESCRIPTION
This PR includes an attempt to fix the issues we were experiencing on Android. There were hundreds of `"Client already logged in"` and `"Client is already connected"` errors which seem to stem from the Android Binding for XMPP. Trying to locate the error message, I found that it is deeply buried inside the XMPP library (called Smack) used by `react-native-xmpp`.

I searched for bugs related to reconnection and found this resolved issue:

> https://issues.igniterealtime.org/browse/SMACK-725
> `ReconnectionManager` should handle `AlreadyConnectedException` and `AlreadyLoggedInException` not as failure

The `react-native-xmpp` package is using Smack 4.1.9 and the issue was fixed in
4.1.8 and 4.2.0, so our version includes the fix as well. However, while iOS does delegate the reconnection logic to the underlying `XMPPReconnect.m` implementation, on Android, the `ReconnectionManager` is not used inside `react-native-xmpp`. Why is not clear, but there are some indications that it doesn't work on Android:
https://stackoverflow.com/a/38178025

Instead, connect binding calls the underlying `connect` and `login` methods every time, which is the same for the `connect` and `reconnect` bindings. Therefore, we try to fix this and be more cautious about doing connection and authentication attempts, as it will always lead to errors when the user already is connected or logged in.