### PR TITLE
Fix/reconnection errors on android

### DIFF
--- a/RNXMPP/RNXMPPService.h
+++ b/RNXMPP/RNXMPPService.h
@@ -9,7 +9,7 @@
 #import <Foundation/Foundation.h>
 
 #import "XMPP.h"
-#import "XMPPStreamManagementMemoryStorage.h"
+// #import "XMPPStreamManagementMemoryStorage.h"
 #import "XMPPReconnect.h"
 #import "XMPPDateTimeProfiles.h"
 #import "NSDate+XMPPDateTimeProfiles.h"
@@ -49,8 +49,8 @@
 
 @property (nonatomic, strong, readonly) XMPPStream *xmppStream;
 @property (nonatomic, strong, readonly) XMPPReconnect *xmppReconnect;
-@property (nonatomic, strong, readonly) XMPPStreamManagementMemoryStorage *xmppStreamStorage;
-@property (nonatomic, strong, readonly) XMPPStreamManagement *xmppStreamMgt;
+// @property (nonatomic, strong, readonly) XMPPStreamManagementMemoryStorage *xmppStreamStorage;
+// @property (nonatomic, strong, readonly) XMPPStreamManagement *xmppStreamMgt;
 @property (nonatomic, strong, readonly) XMPPAutoPing *xmppAutoPing;
 @property (nonatomic, weak) id<RNXMPPServiceDelegate> delegate;
 
@@ -62,4 +62,3 @@
 -(void)sendStanza:(NSString *)stanza;
 
 @end
-

--- a/RNXMPP/RNXMPPService.h
+++ b/RNXMPP/RNXMPPService.h
@@ -9,7 +9,6 @@
 #import <Foundation/Foundation.h>
 
 #import "XMPP.h"
-// #import "XMPPStreamManagementMemoryStorage.h"
 #import "XMPPReconnect.h"
 #import "XMPPDateTimeProfiles.h"
 #import "NSDate+XMPPDateTimeProfiles.h"
@@ -49,8 +48,6 @@
 
 @property (nonatomic, strong, readonly) XMPPStream *xmppStream;
 @property (nonatomic, strong, readonly) XMPPReconnect *xmppReconnect;
-// @property (nonatomic, strong, readonly) XMPPStreamManagementMemoryStorage *xmppStreamStorage;
-// @property (nonatomic, strong, readonly) XMPPStreamManagement *xmppStreamMgt;
 @property (nonatomic, strong, readonly) XMPPAutoPing *xmppAutoPing;
 @property (nonatomic, weak) id<RNXMPPServiceDelegate> delegate;
 

--- a/RNXMPP/RNXMPPService.m
+++ b/RNXMPP/RNXMPPService.m
@@ -36,8 +36,8 @@ static const int ddLogLevel = LOG_LEVEL_INFO;
 
 @synthesize xmppStream;
 @synthesize xmppReconnect;
-@synthesize xmppStreamStorage;
-@synthesize xmppStreamMgt;
+// @synthesize xmppStreamStorage;
+// @synthesize xmppStreamMgt;
 @synthesize xmppAutoPing;
 
 +(RNXMPPService *) sharedInstance {
@@ -90,10 +90,10 @@ static const int ddLogLevel = LOG_LEVEL_INFO;
     }
 #endif
 
-    // Setup xep-0198
-    xmppStreamStorage = [[XMPPStreamManagementMemoryStorage alloc] init];
-    xmppStreamMgt = [[XMPPStreamManagement alloc] initWithStorage: xmppStreamStorage];
-    [xmppStreamMgt activate: xmppStream];
+    // // Setup xep-0198
+    // xmppStreamStorage = [[XMPPStreamManagementMemoryStorage alloc] init];
+    // xmppStreamMgt = [[XMPPStreamManagement alloc] initWithStorage: xmppStreamStorage];
+    // [xmppStreamMgt activate: xmppStream];
 
     // Setup reconnect
     //

--- a/RNXMPP/RNXMPPService.m
+++ b/RNXMPP/RNXMPPService.m
@@ -36,8 +36,6 @@ static const int ddLogLevel = LOG_LEVEL_INFO;
 
 @synthesize xmppStream;
 @synthesize xmppReconnect;
-// @synthesize xmppStreamStorage;
-// @synthesize xmppStreamMgt;
 @synthesize xmppAutoPing;
 
 +(RNXMPPService *) sharedInstance {
@@ -89,11 +87,6 @@ static const int ddLogLevel = LOG_LEVEL_INFO;
         xmppStream.enableBackgroundingOnSocket = YES;
     }
 #endif
-
-    // // Setup xep-0198
-    // xmppStreamStorage = [[XMPPStreamManagementMemoryStorage alloc] init];
-    // xmppStreamMgt = [[XMPPStreamManagement alloc] initWithStorage: xmppStreamStorage];
-    // [xmppStreamMgt activate: xmppStream];
 
     // Setup reconnect
     //

--- a/RNXMPP/XMPPFramework.h
+++ b/RNXMPP/XMPPFramework.h
@@ -42,7 +42,3 @@
 
 #import "XMPPMUC.h"
 #import "XMPPRoomCoreDataStorage.h"
-
-// // xep-0198
-// #import "XMPPStreamManagement.h"
-// #import "XMPPStreamManagementMemoryStorage.h"

--- a/RNXMPP/XMPPFramework.h
+++ b/RNXMPP/XMPPFramework.h
@@ -1,24 +1,24 @@
 //
 //  This file is designed to be customized by YOU.
-//  
+//
 //  As you pick and choose which parts of the framework you need for your application, add them to this header file.
-//  
+//
 //  Various modules available within the framework optionally interact with each other.
 //  E.g. The XMPPPing module will utilize the XMPPCapabilities module (if available) to advertise support XEP-0199.
-// 
+//
 //  However, the modules can only interact if they're both added to your xcode project.
 //  E.g. If XMPPCapabilities isn't a part of your xcode project, then XMPPPing shouldn't attempt to reference it.
-// 
+//
 //  So how do the individual modules know if other modules are available?
 //  Via this header file.
-// 
+//
 //  If you #import "XMPPCapabilities.h" in this file, then _XMPP_CAPABILITIES_H will be defined for other modules.
 //  And they can automatically take advantage of it.
 //
 
 
 //  CUSTOMIZE ME !
-//  
+//
 //  THIS HEADER FILE SHOULD BE TAILORED TO MATCH YOUR APPLICATION.
 
 
@@ -43,6 +43,6 @@
 #import "XMPPMUC.h"
 #import "XMPPRoomCoreDataStorage.h"
 
-// xep-0198
-#import "XMPPStreamManagement.h"
-#import "XMPPStreamManagementMemoryStorage.h"
+// // xep-0198
+// #import "XMPPStreamManagement.h"
+// #import "XMPPStreamManagementMemoryStorage.h"

--- a/android/src/main/java/rnxmpp/service/XmppServiceSmackImpl.java
+++ b/android/src/main/java/rnxmpp/service/XmppServiceSmackImpl.java
@@ -84,8 +84,10 @@ public class XmppServiceSmackImpl implements XmppService, StanzaListener, Connec
             confBuilder.setCustomSSLContext(UnsafeSSLContext.INSTANCE.getContext());
         }
         XMPPTCPConnectionConfiguration connectionConfiguration = confBuilder.build();
-        XMPPTCPConnection.setUseStreamManagementDefault(true);
-        XMPPTCPConnection.setUseStreamManagementResumptionDefault(true);
+        // XEP-0198 Stream Management seems to cause issues with hanging
+        // connections on Android when the App is terminated.
+        // XMPPTCPConnection.setUseStreamManagementDefault(true);
+        // XMPPTCPConnection.setUseStreamManagementResumptionDefault(true);
         connection = new XMPPTCPConnection(connectionConfiguration);
 
         // Disable automatic roster request

--- a/android/src/main/java/rnxmpp/service/XmppServiceSmackImpl.java
+++ b/android/src/main/java/rnxmpp/service/XmppServiceSmackImpl.java
@@ -84,10 +84,6 @@ public class XmppServiceSmackImpl implements XmppService, StanzaListener, Connec
             confBuilder.setCustomSSLContext(UnsafeSSLContext.INSTANCE.getContext());
         }
         XMPPTCPConnectionConfiguration connectionConfiguration = confBuilder.build();
-        // XEP-0198 Stream Management seems to cause issues with hanging
-        // connections on Android when the App is terminated.
-        // XMPPTCPConnection.setUseStreamManagementDefault(true);
-        // XMPPTCPConnection.setUseStreamManagementResumptionDefault(true);
         connection = new XMPPTCPConnection(connectionConfiguration);
 
         // Disable automatic roster request


### PR DESCRIPTION
This PR disables Stream Management, as it seems to be the root cause of undelivered messages on Android when the app is terminated.